### PR TITLE
feat: use tree-sitter and new looks

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -2,8 +2,7 @@
 call plug#begin('~/.vim/plugged')
 " looks
 Plug 'folke/tokyonight.nvim'
-Plug 'vim-airline/vim-airline'
-Plug 'vim-airline/vim-airline-themes'
+Plug 'itchyny/lightline.vim'
 " utilities
 Plug 'junegunn/fzf',           { 'do': { -> fzf#install() } }
 Plug 'junegunn/fzf.vim'
@@ -51,6 +50,7 @@ require("tokyonight").setup({
 })
 EOF
 colorscheme tokyonight
+let g:lightline = {'colorscheme': 'tokyonight'}
 
 " Maps
 cnoreabbrev q1 q!
@@ -91,10 +91,6 @@ nmap Ps :%!gpg --clearsign<CR>
 nmap Pe :%!gpg -er 
 nmap Pb :%!gpg -ser 
 nmap Pd :%!gpg -d<CR>
-
-" Airline
-let g:airline_powerline_fonts = 0
-let g:airline_theme = "papercolor"
 
 " Completion
 lua << EOF

--- a/init.vim
+++ b/init.vim
@@ -51,7 +51,7 @@ lua <<EOF
 EOF
 colorscheme tokyonight-night
 set noshowmode
-let g:lightline = {'colorscheme': 'tokyonight-night'}
+let g:lightline = {'colorscheme': 'tokyonight'}
 
 " Maps
 cnoreabbrev q1 q!

--- a/init.vim
+++ b/init.vim
@@ -43,7 +43,7 @@ set nohls noincsearch
 set completeopt=menuone
 set t_Co=256
 set rnu signcolumn=yes
-syntax on
+"syntax on
 colorscheme molokai
 
 " Maps

--- a/init.vim
+++ b/init.vim
@@ -22,13 +22,9 @@ Plug 'hrsh7th/cmp-buffer'
 Plug 'hrsh7th/cmp-nvim-lsp'
 Plug 'crispgm/cmp-beancount'
 " file types
-Plug 'chr4/nginx.vim',                  { 'for': 'nginx' }
 Plug 'chrisbra/csv.vim',
-Plug 'hashivim/vim-terraform',          { 'for': 'terraform' }
-Plug 'pearofducks/ansible-vim',         { 'for': 'yaml.ansible' }
-Plug 'elixir-editors/vim-elixir',       { 'for': 'elixir' }
 Plug 'nathangrigg/vim-beancount',       { 'for': 'beancount' }
-Plug 'martinda/Jenkinsfile-vim-syntax', { 'for': 'Jenkinsfile' }
+Plug 'nvim-treesitter/nvim-treesitter', { 'do': ':TSUpdate' }
 call plug#end()
 
 " Basics
@@ -237,6 +233,19 @@ cmp.setup({
     end,
   },
 })
+
+-- Treesitter
+require'nvim-treesitter.configs'.setup {
+  ensure_installed = {
+    "c", "lua", "vim", "vimdoc", "query",
+    "python", "hcl", "beancount",
+  },
+  auto_install = true,
+  highlight = {
+    enable = true,
+    additional_vim_regex_highlighting = false,
+  },
+}
 EOF
 
 " ALE

--- a/init.vim
+++ b/init.vim
@@ -45,13 +45,13 @@ set rnu signcolumn=yes
 
 " Looks
 lua <<EOF
-require("tokyonight").setup({
-  transparent = true,
-})
+--require("tokyonight").setup({
+--  transparent = true,
+--})
 EOF
-colorscheme tokyonight
+colorscheme tokyonight-night
 set noshowmode
-let g:lightline = {'colorscheme': 'tokyonight'}
+let g:lightline = {'colorscheme': 'tokyonight-night'}
 
 " Maps
 cnoreabbrev q1 q!

--- a/init.vim
+++ b/init.vim
@@ -40,7 +40,6 @@ set splitright splitbelow
 set undofile undodir=~/.vim/undodir
 set nohls noincsearch
 set completeopt=menuone
-set t_Co=256
 set rnu signcolumn=yes
 
 " Looks
@@ -49,6 +48,7 @@ lua <<EOF
 --  transparent = true,
 --})
 EOF
+set termguicolors
 colorscheme tokyonight-night
 set noshowmode
 let g:lightline = {'colorscheme': 'tokyonight'}

--- a/init.vim
+++ b/init.vim
@@ -77,7 +77,7 @@ autocmd FileType sh imap <F3> #!/bin/bash -<CR><CR>
 autocmd FileType python imap <F3> #!/usr/bin/env python<CR><CR>
 autocmd FileType python set softtabstop=4 expandtab shiftwidth=4
 autocmd FileType csv nmap <C-k> :WhatColumn!<CR>
-autocmd FileType terraform set foldmethod=syntax nofoldenable
+autocmd FileType terraform set foldmethod=expr foldexpr=nvim_treesitter#foldexpr() nofoldenable
 
 " GnuPG
 set noshelltemp

--- a/init.vim
+++ b/init.vim
@@ -238,7 +238,7 @@ cmp.setup({
 require'nvim-treesitter.configs'.setup {
   ensure_installed = {
     "c", "lua", "vim", "vimdoc", "query",
-    "python", "hcl", "beancount",
+    "python", "terraform", "beancount",
   },
   auto_install = true,
   highlight = {

--- a/init.vim
+++ b/init.vim
@@ -50,6 +50,7 @@ require("tokyonight").setup({
 })
 EOF
 colorscheme tokyonight
+set noshowmode
 let g:lightline = {'colorscheme': 'tokyonight'}
 
 " Maps

--- a/init.vim
+++ b/init.vim
@@ -1,7 +1,7 @@
 " Plugins
 call plug#begin('~/.vim/plugged')
 " looks
-Plug 'bigeagle/molokai'
+Plug 'folke/tokyonight.nvim'
 Plug 'vim-airline/vim-airline'
 Plug 'vim-airline/vim-airline-themes'
 " utilities
@@ -43,8 +43,14 @@ set nohls noincsearch
 set completeopt=menuone
 set t_Co=256
 set rnu signcolumn=yes
-"syntax on
-colorscheme molokai
+
+" Looks
+lua <<EOF
+require("tokyonight").setup({
+  transparent = true,
+})
+EOF
+colorscheme tokyonight
 
 " Maps
 cnoreabbrev q1 q!


### PR DESCRIPTION
- Add treesitter; remove various syntax plugins
- Naming
- Set foldmethod to treesitter
- Turn off regex-based syntax highlighting
- Use TokyoNight colorscheme
- Replace airline vs lightline and use tokyonight cs
- Hide current mode as lightline displays it already
- Disable transparency bg; explicitly use -night variant
- fix(lightline): invalid theme name
- feat: enable true color; remove legacy vim t_xx opts
